### PR TITLE
Make composer name lowercase and remove version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,7 @@
 {
-    "name": "Gw/AutoCustomerGroup",
+    "name": "gw/autocustomergroup",
     "description": "GW AutoCustomerGroup",
     "type": "magento2-module",
-    "version": "1.0.0",
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
Hi!

This consists of 2 changes:
- Changed name to prevent composer from outputting: `Deprecation warning: require.Gw/AutoCustomerGroup is invalid, it should not contain uppercase characters. Please use gw/autocustomergroup instead. Make sure you fix this as Composer 2.0 will error.`
- Removed version from `composer.json` file, if you have no automated script to bump the version while you release a new one, this can often lead to oversights and problems with composer. It's easier to tag a new version in git, composer will then use the version from the tag instead of the version declared inside the `composer.json` file

Remark for later:
It's better not to declare version constraints as `"*"` on magento module, because we can't predict if newer versions of these modules will still be compatible. This is probably not important right now because this module is still considered bèta, but the moment you feel like this is more or less stable, the constraints should get tightened a bit more.

Additional question: has the module been tested on Magento 2.3.x and 2.4.x or are you currently only focussing on the latest Magento version?