### PR TITLE
Applied some small cleanup here and there based on phpstan output

### DIFF
--- a/Model/AutoCustomerGroup.php
+++ b/Model/AutoCustomerGroup.php
@@ -47,7 +47,7 @@ class AutoCustomerGroup
      * @param DataObject $taxIdValidationResults
      * @param Quote $quote
      * @param int $storeId
-     * @return void
+     * @return int|null
      */
     public function getCustomerGroup(
         $customerCountryCode,

--- a/Model/TaxSchemes/AbstractTaxScheme.php
+++ b/Model/TaxSchemes/AbstractTaxScheme.php
@@ -3,6 +3,7 @@ namespace Gw\AutoCustomerGroup\Model\TaxSchemes;
 
 use Gw\AutoCustomerGroup\Helper\AutoCustomerGroup;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\DataObject;
 use Magento\Quote\Model\Quote;
 use Magento\Store\Model\ScopeInterface;
 use Psr\Log\LoggerInterface;

--- a/Model/TaxSchemes/AustraliaGst.php
+++ b/Model/TaxSchemes/AustraliaGst.php
@@ -248,7 +248,7 @@ class AustraliaGst extends AbstractTaxScheme
         // Sum the products
         $sum = 0;
         foreach (str_split($abn) as $key => $digit) {
-            $sum += ($digit * $weights[$key]);
+            $sum += ((int) $digit * $weights[$key]);
         }
 
         if (($sum % 89) != 0) {

--- a/Model/TaxSchemes/EuVat.php
+++ b/Model/TaxSchemes/EuVat.php
@@ -36,7 +36,7 @@ class EuVat extends AbstractTaxScheme
      * @param DataObject $vatValidationResult
      * @param Quote $quote
      * @param $store
-     * @return int
+     * @return int|null
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)

--- a/Model/TaxSchemes/NewZealandGst.php
+++ b/Model/TaxSchemes/NewZealandGst.php
@@ -168,7 +168,7 @@ class NewZealandGst extends AbstractTaxScheme
         }
         $sum = 0;
         foreach (str_split($withoutcheck) as $key => $digit) {
-            $sum += ($digit * $weightsa[$key]);
+            $sum += ((int) $digit * $weightsa[$key]);
         }
         $remainder = $sum % 11;
         if ($remainder == 0) {
@@ -178,7 +178,7 @@ class NewZealandGst extends AbstractTaxScheme
             if ($calculatedCheck == 10) {
                 $sum = 0;
                 foreach (str_split($withoutcheck) as $key => $digit) {
-                    $sum += ($digit * $weightsb[$key]);
+                    $sum += ((int) $digit * $weightsb[$key]);
                 }
                 $remainder = $sum % 11;
                 if ($remainder == 0) {
@@ -194,5 +194,6 @@ class NewZealandGst extends AbstractTaxScheme
         if ($calculatedCheck == $check) {
             return true;
         }
+        return false;
     }
 }


### PR DESCRIPTION
Fixes the following things [phpstan](https://github.com/phpstan/phpstan/) reported on level 3:

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------
  Line   Model/AutoCustomerGroup.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------
  61     Method Gw\AutoCustomerGroup\Model\AutoCustomerGroup::getCustomerGroup() with return type void returns mixed but should not return anything.
  70     Method Gw\AutoCustomerGroup\Model\AutoCustomerGroup::getCustomerGroup() with return type void returns null but should not return anything.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Model/TaxSchemes/AbstractTaxScheme.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  127    Parameter $validationResult of method Gw\AutoCustomerGroup\Model\TaxSchemes\AbstractTaxScheme::isValid() has invalid typehint type Gw\AutoCustomerGroup\Model\TaxSchemes\DataObject.
  129    Call to method getIsValid() on an unknown class Gw\AutoCustomerGroup\Model\TaxSchemes\DataObject.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  129    Call to method getRequestSuccess() on an unknown class Gw\AutoCustomerGroup\Model\TaxSchemes\DataObject.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------------------
  Line   Model/TaxSchemes/AustraliaGst.php
 ------ ------------------------------------------------------------------------------------------------------
  251    Binary operation "*" between string and int results in an error.
 ------ ------------------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------------------------
  Line   Model/TaxSchemes/EuVat.php
 ------ ------------------------------------------------------------------------------------------------------------
  140    Method Gw\AutoCustomerGroup\Model\TaxSchemes\EuVat::getCustomerGroup() should return int but returns null.
 ------ ------------------------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------------------------------------------
  Line   Model/TaxSchemes/NewZealandGst.php
 ------ ------------------------------------------------------------------------------------------------------------------------------
  171    Binary operation "*" between string and 2|3|4|5|6|7 results in an error.
  181    Binary operation "*" between string and 2|3|4|5|6|7 results in an error.
  194    Method Gw\AutoCustomerGroup\Model\TaxSchemes\NewZealandGst::isValidGst() should return bool but return statement is missing.
 ------ ------------------------------------------------------------------------------------------------------------------------------
```