### PR TITLE
Broadened composer version constraints so the module can be installed on Magento 2.3.0 => 2.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         }
     },
     "require": {
-        "magento/module-tax": "100.4.*",
-        "magento/module-customer": "103.0.*",
-        "magento/module-directory": "100.4.*",
-        "magento/framework": "103.0.*",
-        "magento/module-store": "101.1.*",
-        "magento/module-quote": "101.2.*",
-        "magento/module-config": "101.2.*",
+        "magento/module-tax": "^100.3.0",
+        "magento/module-customer": "^102.0.0 || ^103.0.0",
+        "magento/module-directory": "^100.3.0",
+        "magento/framework": "^102.0.0 || ^103.0.0",
+        "magento/module-store": "^101.0.0",
+        "magento/module-quote": "^101.1.0",
+        "magento/module-config": "^101.1.0",
         "ext-soap": "*",
         "guzzlehttp/guzzle": "^6.3.3"
     }


### PR DESCRIPTION
I've changed the composer version constraints of the Magento modules being used so the module can be installed on Magento >= 2.3.0 and < 2.5.0
Also the format of the constraints is changed so it allows for [semver](https://semver.org/) compatible updates, which Magento module's do use.

I've ran phpstan with level 8 on Magento 2.3.0 components using PHP 7.2 and Magento 2.4.1 components using PHP 7.4 and it only detected a minor difference which had to do with changes [of the phpdoc annotations in Magento 2.3.3 on the `ScopeConfigInterface:: getValue` method](https://github.com/magento/magento2/commit/7653c8027da741f7f08cefc708071593a0480e6d#diff-c15a3698dacd7193d3198ec667f47188ba274e96cbe1aa7b1a0c1f77d73131ba), but that should cause no issues in practice.

I think this is safe enough to assume the module in its current form should work on Magento 2.3 shops as well